### PR TITLE
Adicionando .gitignore ao projeto

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+**/.DS_Store
+*~
+*.swp
+*.tmp
+*.aux
+*.log
+*.out
+node_modules


### PR DESCRIPTION
Adicionando gitignore ao projeto, isso é importante para que não seja incluido arquivos temporários ou inúteis na versão final.